### PR TITLE
Get tag "yt-formatted-string" rather than "a"

### DIFF
--- a/AntiTranslate.user.js
+++ b/AntiTranslate.user.js
@@ -75,7 +75,7 @@
         var APIcallIDs;
 
         // REFERENCED VIDEO TITLES - find video link elements in the page that have not yet been changed
-        var links = Array.prototype.slice.call(document.getElementsByTagName("a")).filter( a => {
+        var links = Array.prototype.slice.call(document.getElementsByTagName("yt-formatted-string")).filter( a => {
             return a.id == 'video-title' && alreadyChanged.indexOf(a) == -1;
         } );
         var spans = Array.prototype.slice.call(document.getElementsByTagName("span")).filter( a => {


### PR DESCRIPTION
Seems like someone at youtube likes more verbose names, or they are tidying some stuff.

But it broke the script for the main page.

Fixes titles not being translated on home page, haven't seen unwanted
effects so far.

Let me know if this is not the proper way of doing this.

Cheers