### PR TITLE
fix main video title and description

### DIFF
--- a/AntiTranslate.user.js
+++ b/AntiTranslate.user.js
@@ -61,6 +61,8 @@
         if(currentLocation !== document.title) resetChanged();
 
         // MAIN TITLE - no API key required
+        //No longer work
+        /*
         if (window.location.href.includes ("/watch")){
             var titleMatch = document.title.match (/^(?:\([0-9]+\) )?(.*?)(?: - YouTube)$/); // ("(n) ") + "TITLE - YouTube"
             var pageTitle = document.getElementsByClassName("title style-scope ytd-video-primary-info-renderer");
@@ -71,6 +73,7 @@
                 }
             }
         }
+        */
 
         if (NO_API_KEY) {
             return;
@@ -124,14 +127,24 @@
                         { // Replace Main Video Description
                             var videoDescription = data[0].snippet.description;
                             var pageDescription = document.getElementsByClassName("content style-scope ytd-video-secondary-info-renderer");
-                            if (pageDescription.length > 0 && videoDescription != null && pageDescription[0] !== undefined) {
+                            if (pageDescription.length > 0 && videoDescription != null) {
                                 // linkify replaces links correctly, but without redirect or other specific youtube stuff (no problem if missing)
                                 // Still critical, since it replaces ALL descriptions, even if it was not translated in the first place (no easy comparision possible)
-                                pageDescription[0].innerHTML = linkify(videoDescription);
-                                console.log ("Reverting main video description!");
-                                changedDescription = true;
+                                for(let pd of pageDescription)
+                                {
+                                    pd.innerHTML = linkify(videoDescription);
+                                    console.log ("Reverting main video description!");
+                                    changedDescription = true;
+                                }
                             }
                             else console.log ("Failed to find main video description!");
+
+                            const mainTitle = document.querySelector("ytd-watch-flexy:not([hidden]) #container > h1 > yt-formatted-string");
+                            if(mainTitle)
+                            {
+                                console.log ("Reverting main video title '" + mainTitle.innerHTML + "' to '" + data[0].snippet.title + "'");
+                                mainTitle.innerHTML = data[0].snippet.title;
+                            }
                         }
 
                         // Create dictionary for all IDs and their original titles


### PR DESCRIPTION
Reading `document.title` no longer work since it is also translated.
Also `pageDescription` might be an array and the first element might not be the visible one.